### PR TITLE
Set actual hour with working day

### DIFF
--- a/lambda/src/main/java/com/lambda/IssueUpdater.java
+++ b/lambda/src/main/java/com/lambda/IssueUpdater.java
@@ -72,7 +72,7 @@ public class IssueUpdater {
         if (!field.isPresent())
             return null;
 
-        String startedAt = LocalDateTime.now().toString();
+        String startedAt = LocalDateTime.ofInstant(Instant.now(), ZoneId.of("Asia/Tokyo")).toString();
         return client.updateIssue(new UpdateIssueParams(issue.getId()).textCustomField(field.get().getId(), startedAt));
     }
 }

--- a/lambda/src/main/java/com/lambda/IssueUpdater.java
+++ b/lambda/src/main/java/com/lambda/IssueUpdater.java
@@ -22,6 +22,8 @@ public class IssueUpdater {
 
     static private final String CUSTOM_FIELD_STARTED_AT = "Started at";
     private static final ZoneId JST_ZONE = ZoneId.of("Asia/Tokyo");
+    private static final List<DayOfWeek> WEEKENDS = Arrays.asList(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY);
+
 
     public IssueUpdater(final String apiKey) {
         configure = new BacklogJpConfigure("faber-wi").apiKey(apiKey);
@@ -72,8 +74,7 @@ public class IssueUpdater {
         Duration totalWorkingDuration = Duration.ZERO;
 
         while (current.isBefore(end)) {
-            // Only count weekdays
-            if (current.getDayOfWeek() != DayOfWeek.SATURDAY && current.getDayOfWeek() != DayOfWeek.SUNDAY) {
+            if (isWeekday(current)) {
                 LocalDateTime endOfDay = current.withHour(19).withMinute(30); // End at 17:30 ITC as 19:30 JST
                 
                 // Add hours for current day or until end time
@@ -86,6 +87,10 @@ public class IssueUpdater {
         }
 
         return totalWorkingDuration;
+    }
+
+    private boolean isWeekday(LocalDateTime dateTime) {
+        return !WEEKENDS.contains(dateTime.getDayOfWeek());
     }
 
     private boolean isSameDate(LocalDateTime dateTime1, LocalDateTime dateTime2) {

--- a/lambda/src/main/java/com/lambda/IssueUpdater.java
+++ b/lambda/src/main/java/com/lambda/IssueUpdater.java
@@ -24,7 +24,7 @@ public class IssueUpdater {
     private BacklogConfigure configure;
     private BacklogClient client;
 
-    static private final String CUSTOM_FIELD_STARTED_AT = "Started at";
+    private static final String CUSTOM_FIELD_STARTED_AT = "Started at";
     private static final ZoneId JST_ZONE = ZoneId.of("Asia/Tokyo");
     private static final List<DayOfWeek> WEEKENDS = Arrays.asList(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY);
 

--- a/lambda/src/main/java/com/lambda/IssueUpdater.java
+++ b/lambda/src/main/java/com/lambda/IssueUpdater.java
@@ -1,16 +1,13 @@
 package com.lambda;
 
+import com.lambda.utils.WorkdayUtils;
 import java.text.DecimalFormat;
-import java.time.DayOfWeek;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeParseException;
 import java.util.Optional;
-import java.util.Arrays;
-import java.util.List;
 
 import com.nulabinc.backlog4j.BacklogClient;
 import com.nulabinc.backlog4j.BacklogClientFactory;
@@ -27,9 +24,6 @@ public class IssueUpdater {
 
     private static final String CUSTOM_FIELD_STARTED_AT = "Started at";
     private static final ZoneId JST_ZONE = ZoneId.of("Asia/Tokyo");
-    private static final List<DayOfWeek> WEEKENDS = Arrays.asList(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY);
-    private static final LocalTime WORK_START_TIME = LocalTime.of(9, 30); // Start at 09:30 JST
-    private static final LocalTime WORK_END_TIME = LocalTime.of(19, 30); // End at 17:30 ICT as 19:30 JST
 
 
     public IssueUpdater(final String apiKey) {
@@ -55,7 +49,7 @@ public class IssueUpdater {
                 // get elapsed time from the started time in hours
                 try {
                     LocalDateTime endAt = LocalDateTime.ofInstant(Instant.now(), JST_ZONE);
-                    elapsed = calculateWorkingHours(LocalDateTime.parse(startedAtValue), endAt);
+                    elapsed = new WorkdayUtils().calculateWorkingHours(LocalDateTime.parse(startedAtValue), endAt);
                 } catch (DateTimeParseException ex) {
                 }
             }
@@ -74,34 +68,6 @@ public class IssueUpdater {
             return null;
 
         return client.updateIssue(new UpdateIssueParams(issue.getId()).actualHours(actualHours));
-    }
-
-    private Duration calculateWorkingHours(final LocalDateTime start, final LocalDateTime end) {
-        LocalDateTime current = start;
-        Duration totalWorkingDuration = Duration.ZERO;
-
-        while (current.isBefore(end)) {
-            if (isWeekday(current)) {
-                LocalDateTime endOfDay = current.toLocalDate().atTime(WORK_END_TIME); 
-                
-                // Add hours for current day or until end time
-                LocalDateTime actualEnd = isSameDate(end, endOfDay) ? end : endOfDay;
-                totalWorkingDuration = totalWorkingDuration.plus(Duration.between(current, actualEnd));
-            }
-
-            // Move to the next day
-            current = current.plusDays(1).toLocalDate().atTime(WORK_START_TIME);
-        }
-
-        return totalWorkingDuration;
-    }
-
-    private boolean isWeekday(final LocalDateTime dateTime) {
-        return !WEEKENDS.contains(dateTime.getDayOfWeek());
-    }
-
-    private boolean isSameDate(final LocalDateTime dateTime1, final LocalDateTime dateTime2) {
-        return dateTime1.toLocalDate().equals(dateTime2.toLocalDate());
     }
 
     public Issue setStartedAt(final int issueId) {

--- a/lambda/src/main/java/com/lambda/IssueUpdater.java
+++ b/lambda/src/main/java/com/lambda/IssueUpdater.java
@@ -5,6 +5,7 @@ import java.time.DayOfWeek;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeParseException;
 import java.util.Optional;
@@ -27,6 +28,8 @@ public class IssueUpdater {
     private static final String CUSTOM_FIELD_STARTED_AT = "Started at";
     private static final ZoneId JST_ZONE = ZoneId.of("Asia/Tokyo");
     private static final List<DayOfWeek> WEEKENDS = Arrays.asList(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY);
+    private static final LocalTime WORK_START_TIME = LocalTime.of(9, 30); // Start at 09:30 JST
+    private static final LocalTime WORK_END_TIME = LocalTime.of(19, 30); // End at 17:30 ICT as 19:30 JST
 
 
     public IssueUpdater(final String apiKey) {
@@ -79,15 +82,15 @@ public class IssueUpdater {
 
         while (current.isBefore(end)) {
             if (isWeekday(current)) {
-                LocalDateTime endOfDay = current.withHour(19).withMinute(30); // End at 17:30 ICT as 19:30 JST
+                LocalDateTime endOfDay = current.toLocalDate().atTime(WORK_END_TIME); 
                 
                 // Add hours for current day or until end time
                 LocalDateTime actualEnd = isSameDate(end, endOfDay) ? end : endOfDay;
                 totalWorkingDuration = totalWorkingDuration.plus(Duration.between(current, actualEnd));
             }
 
-            // Move to the next day at 09:30 JST
-            current = current.plusDays(1).withHour(9).withMinute(30);
+            // Move to the next day
+            current = current.plusDays(1).toLocalDate().atTime(WORK_START_TIME);
         }
 
         return totalWorkingDuration;

--- a/lambda/src/main/java/com/lambda/IssueUpdater.java
+++ b/lambda/src/main/java/com/lambda/IssueUpdater.java
@@ -1,11 +1,15 @@
 package com.lambda;
 
 import java.text.DecimalFormat;
+import java.time.DayOfWeek;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeParseException;
 import java.util.Optional;
+import java.util.Arrays;
+import java.util.List;
 
 import com.nulabinc.backlog4j.BacklogClient;
 import com.nulabinc.backlog4j.BacklogClientFactory;

--- a/lambda/src/main/java/com/lambda/IssueUpdater.java
+++ b/lambda/src/main/java/com/lambda/IssueUpdater.java
@@ -79,7 +79,7 @@ public class IssueUpdater {
 
         while (current.isBefore(end)) {
             if (isWeekday(current)) {
-                LocalDateTime endOfDay = current.withHour(19).withMinute(30); // End at 17:30 ITC as 19:30 JST
+                LocalDateTime endOfDay = current.withHour(19).withMinute(30); // End at 17:30 ICT as 19:30 JST
                 
                 // Add hours for current day or until end time
                 LocalDateTime actualEnd = isSameDate(end, endOfDay) ? end : endOfDay;

--- a/lambda/src/main/java/com/lambda/IssueUpdater.java
+++ b/lambda/src/main/java/com/lambda/IssueUpdater.java
@@ -57,7 +57,7 @@ public class IssueUpdater {
                     LocalDateTime.now());
         }
         DecimalFormat df = new DecimalFormat("0.0");
-        float actualHours = Float.parseFloat((df.format(elapsed.toMinutes() / 60)));
+        float actualHours = Float.parseFloat((df.format(elapsed.toMinutes() / 60.0)));
 
         if (actualHours > 999 || actualHours < 0)
             return null;

--- a/lambda/src/main/java/com/lambda/IssueUpdater.java
+++ b/lambda/src/main/java/com/lambda/IssueUpdater.java
@@ -76,7 +76,7 @@ public class IssueUpdater {
         return client.updateIssue(new UpdateIssueParams(issue.getId()).actualHours(actualHours));
     }
 
-    private Duration calculateWorkingHours(LocalDateTime start, LocalDateTime end) {
+    private Duration calculateWorkingHours(final LocalDateTime start, final LocalDateTime end) {
         LocalDateTime current = start;
         Duration totalWorkingDuration = Duration.ZERO;
 
@@ -96,11 +96,11 @@ public class IssueUpdater {
         return totalWorkingDuration;
     }
 
-    private boolean isWeekday(LocalDateTime dateTime) {
+    private boolean isWeekday(final LocalDateTime dateTime) {
         return !WEEKENDS.contains(dateTime.getDayOfWeek());
     }
 
-    private boolean isSameDate(LocalDateTime dateTime1, LocalDateTime dateTime2) {
+    private boolean isSameDate(final LocalDateTime dateTime1, final LocalDateTime dateTime2) {
         return dateTime1.toLocalDate().equals(dateTime2.toLocalDate());
     }
 

--- a/lambda/src/main/java/com/lambda/IssueUpdater.java
+++ b/lambda/src/main/java/com/lambda/IssueUpdater.java
@@ -21,6 +21,7 @@ public class IssueUpdater {
     private BacklogClient client;
 
     static private final String CUSTOM_FIELD_STARTED_AT = "Started at";
+    private static final ZoneId JST_ZONE = ZoneId.of("Asia/Tokyo");
 
     public IssueUpdater(final String apiKey) {
         configure = new BacklogJpConfigure("faber-wi").apiKey(apiKey);
@@ -44,7 +45,7 @@ public class IssueUpdater {
             if (startedAtValue != null && !startedAtValue.isBlank()) {
                 // get elapsed time from the started time in hours
                 try {
-                    LocalDateTime endAt = LocalDateTime.ofInstant(Instant.now(), ZoneId.of("Asia/Tokyo"));
+                    LocalDateTime endAt = LocalDateTime.ofInstant(Instant.now(), JST_ZONE);
                     elapsed = calculateWorkingHours(LocalDateTime.parse(startedAtValue), endAt);
                 } catch (DateTimeParseException ex) {
                 }
@@ -98,7 +99,7 @@ public class IssueUpdater {
         if (!field.isPresent())
             return null;
 
-        String startedAt = LocalDateTime.ofInstant(Instant.now(), ZoneId.of("Asia/Tokyo")).toString();
+        String startedAt = LocalDateTime.ofInstant(Instant.now(), JST_ZONE).toString();
         return client.updateIssue(new UpdateIssueParams(issue.getId()).textCustomField(field.get().getId(), startedAt));
     }
 }

--- a/lambda/src/main/java/com/lambda/utils/WorkdayUtils.java
+++ b/lambda/src/main/java/com/lambda/utils/WorkdayUtils.java
@@ -1,0 +1,43 @@
+package com.lambda.utils;
+
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.List;
+
+public class WorkdayUtils {
+    
+    private static final List<DayOfWeek> WEEKENDS = Arrays.asList(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY);
+    private static final LocalTime WORK_START_TIME = LocalTime.of(9, 30); // Start at 09:30 JST
+    private static final LocalTime WORK_END_TIME = LocalTime.of(19, 30); // End at 17:30 ICT as 19:30 JST
+    
+    public Duration calculateWorkingHours(final LocalDateTime start, final LocalDateTime end) {
+        LocalDateTime current = start;
+        Duration totalWorkingDuration = Duration.ZERO;
+
+        while (current.isBefore(end)) {
+            if (isWeekday(current)) {
+                LocalDateTime endOfDay = current.toLocalDate().atTime(WORK_END_TIME); 
+                
+                // Add hours for current day or until end time
+                LocalDateTime actualEnd = isSameDate(end, endOfDay) ? end : endOfDay;
+                totalWorkingDuration = totalWorkingDuration.plus(Duration.between(current, actualEnd));
+            }
+
+            // Move to the next day
+            current = current.plusDays(1).toLocalDate().atTime(WORK_START_TIME);
+        }
+
+        return totalWorkingDuration;
+    }
+
+    private boolean isWeekday(final LocalDateTime dateTime) {
+        return !WEEKENDS.contains(dateTime.getDayOfWeek());
+    }
+
+    private boolean isSameDate(final LocalDateTime dateTime1, final LocalDateTime dateTime2) {
+        return dateTime1.toLocalDate().equals(dateTime2.toLocalDate());
+    }
+}

--- a/lambda/src/test/java/com/lambda/utils/WorkdayUtilsTest.java
+++ b/lambda/src/test/java/com/lambda/utils/WorkdayUtilsTest.java
@@ -1,0 +1,89 @@
+package com.lambda.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+public class WorkdayUtilsTest {
+
+    private final WorkdayUtils utils = new WorkdayUtils();
+
+    @Test
+    public void testCalculateWorkingHours_FullWeekday() {
+        // Start and end on a weekday within working hours
+        LocalDateTime start = LocalDateTime.of(2024, 11, 19, 10, 0);
+        LocalDateTime end = LocalDateTime.of(2024, 11, 19, 18, 0);
+
+        Duration expected = Duration.between(LocalTime.of(10, 0), LocalTime.of(18, 0));
+        Duration actual = utils.calculateWorkingHours(start, end);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testCalculateWorkingHours_StartBeforeWorkday() {
+        // Start before workday, end within workday
+        LocalDateTime start = LocalDateTime.of(2024, 11, 19, 8, 0);
+        LocalDateTime end = LocalDateTime.of(2024, 11, 19, 15, 0);
+
+        Duration expected = Duration.between(LocalTime.of(8, 0), LocalTime.of(15, 0));
+        Duration actual = utils.calculateWorkingHours(start, end);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testCalculateWorkingHours_EndAfterWorkday() {
+        // Start within workday, end after workday
+        LocalDateTime start = LocalDateTime.of(2024, 11, 19, 14, 0);
+        LocalDateTime end = LocalDateTime.of(2024, 11, 19, 20, 0);
+
+        Duration expected = Duration.between(LocalTime.of(14, 0), LocalTime.of(20, 0));
+        Duration actual = utils.calculateWorkingHours(start, end);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testCalculateWorkingHours_Weekend() {
+        // Start and end on a weekend
+        LocalDateTime start = LocalDateTime.of(2024, 11, 16, 10, 0); // Saturday
+        LocalDateTime end = LocalDateTime.of(2024, 11, 17, 18, 0); // Sunday
+
+        Duration expected = Duration.ZERO;
+        Duration actual = utils.calculateWorkingHours(start, end);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testCalculateWorkingHours_AcrossMultipleDays() {
+        // Start on one day, end on another day
+        LocalDateTime start = LocalDateTime.of(2024, 11, 18, 16, 0); // Monday
+        LocalDateTime end = LocalDateTime.of(2024, 11, 19, 11, 0); // Tuesday
+
+        Duration expected = Duration.between(LocalTime.of(16, 0), LocalTime.of(19, 30))
+                .plus(Duration.between(LocalTime.of(9, 30), LocalTime.of(11, 0)));
+        Duration actual = utils.calculateWorkingHours(start, end);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testCalculateWorkingHours_AcrossWeekend() {
+        // Start on Friday, end on Monday (across weekend)
+        LocalDateTime start = LocalDateTime.of(2024, 11, 15, 13, 0); // Friday
+        LocalDateTime end = LocalDateTime.of(2024, 11, 18, 10, 0); // Monday
+
+        Duration expected = Duration.ofHours(6).plusMinutes(30) // Friday
+                .plus(Duration.ofHours(0).plusMinutes(30)); // Monday
+        Duration actual = utils.calculateWorkingHours(start, end);
+
+        assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
To accurately assess the man-hours used for each PBI task, 
we adjust the calculation to measure only the actual working hours.


Note: Due to the different time zones between Japan and Vietnam, 
we will align our working hours by:
- starting at the same time as Japan's working hours
- ending at the same time as Vietnam's working hours.

Note 2: The calculation may be incorrect on national holidays.