### PR TITLE
Feature/combine-started-time-log

### DIFF
--- a/lambda/src/main/java/com/lambda/BacklogTimeRecorder.java
+++ b/lambda/src/main/java/com/lambda/BacklogTimeRecorder.java
@@ -68,12 +68,6 @@ public class BacklogTimeRecorder implements RequestHandler<APIGatewayV2HTTPEvent
             return returnText("No issue to update", 200);
         }
 
-        if (updatedIssue.getActualHours() != null) {
-            return returnText("Updated", 200);
-        } else {
-            return returnText("Failed to update", 500);
-        }
-
         return returnText(issue.getSummary(), 202);
     }
 

--- a/lambda/src/main/java/com/lambda/BacklogTimeRecorder.java
+++ b/lambda/src/main/java/com/lambda/BacklogTimeRecorder.java
@@ -32,12 +32,6 @@ public class BacklogTimeRecorder implements RequestHandler<APIGatewayV2HTTPEvent
             return returnText("Issue is null", 204);
         }
 
-        final String apiKey = System.getenv("BACKLOG_API_KEY");
-        if (apiKey == null) {
-            throw new RuntimeException("BACKLOG_API_KEY is not set");
-        }
-        final IssueUpdater updater = new IssueUpdater(apiKey);
-
         int newStatus = issue.getChanges().stream()
             .filter(change -> change.getField().equals("status"))
             .findFirst()
@@ -46,6 +40,12 @@ public class BacklogTimeRecorder implements RequestHandler<APIGatewayV2HTTPEvent
         if (newStatus == -1) {
             return returnText("Status did not change", 204);
         }
+
+        final String apiKey = System.getenv("BACKLOG_API_KEY");
+        if (apiKey == null) {
+            throw new RuntimeException("BACKLOG_API_KEY is not set");
+        }
+        final IssueUpdater updater = new IssueUpdater(apiKey);
 
         com.nulabinc.backlog4j.Issue updatedIssue = null;
         switch (StatusType.valueOf(newStatus)) {

--- a/lambda/src/main/java/com/lambda/BacklogTimeRecorder.java
+++ b/lambda/src/main/java/com/lambda/BacklogTimeRecorder.java
@@ -36,8 +36,8 @@ public class BacklogTimeRecorder implements RequestHandler<APIGatewayV2HTTPEvent
             .filter(change -> change.getField().equals("status"))
             .findFirst()
             .map(change -> Integer.parseInt(change.getNewValue()))
-            .orElse(-1);
-        if (newStatus == -1) {
+            .orElse(0);
+        if (newStatus == 0) {
             return returnText("Status did not change", 204);
         }
 

--- a/lambda/src/main/java/com/lambda/BacklogTimeRecorder.java
+++ b/lambda/src/main/java/com/lambda/BacklogTimeRecorder.java
@@ -32,11 +32,6 @@ public class BacklogTimeRecorder implements RequestHandler<APIGatewayV2HTTPEvent
             return returnText("Issue is null", 204);
         }
 
-        final StatusType statusType = issue.getStatus().getStatusType();
-        if (!(statusType == StatusType.Closed || statusType == StatusType.InProgress)) {
-            return returnText("Issue is not closed or in progress", 204);
-        }
-
         final String apiKey = System.getenv("BACKLOG_API_KEY");
         if (apiKey == null) {
             throw new RuntimeException("BACKLOG_API_KEY is not set");
@@ -54,15 +49,15 @@ public class BacklogTimeRecorder implements RequestHandler<APIGatewayV2HTTPEvent
 
         com.nulabinc.backlog4j.Issue updatedIssue = null;
         switch (StatusType.valueOf(newStatus)) {
-            case Closed:
-                updatedIssue = updater.setActualHours(issue.getId());
-                break;
-            case InProgress:
-                updatedIssue = updater.setStartedAt(issue.getId());
-                break;
-            default:
-                return returnText("Unhandled status change", 204);
-        }
+        case Closed:
+            updatedIssue = updater.setActualHours(issue.getId());
+            break;
+        case InProgress, Open:
+            updatedIssue = updater.setStartedAt(issue.getId());
+            break;
+        default:
+            return returnText("Unhandled status change", 204);
+            }
 
         if (updatedIssue == null) {
             return returnText("No issue to update", 200);

--- a/lambda/src/main/java/com/lambda/BacklogTimeRecorder.java
+++ b/lambda/src/main/java/com/lambda/BacklogTimeRecorder.java
@@ -49,15 +49,15 @@ public class BacklogTimeRecorder implements RequestHandler<APIGatewayV2HTTPEvent
 
         com.nulabinc.backlog4j.Issue updatedIssue = null;
         switch (StatusType.valueOf(newStatus)) {
-        case Closed:
-            updatedIssue = updater.setActualHours(issue.getId());
-            break;
-        case InProgress, Open:
-            updatedIssue = updater.setStartedAt(issue.getId());
-            break;
-        default:
-            return returnText("Unhandled status change", 204);
-            }
+            case Closed:
+                updatedIssue = updater.setActualHours(issue.getId());
+                break;
+            case InProgress, Open:
+                updatedIssue = updater.setStartedAt(issue.getId());
+                break;
+            default:
+                return returnText("Unhandled status change", 204);
+        }
 
         if (updatedIssue == null) {
             return returnText("No issue to update", 200);

--- a/lambda/src/main/java/com/lambda/IssueUpdater.java
+++ b/lambda/src/main/java/com/lambda/IssueUpdater.java
@@ -78,6 +78,10 @@ public class IssueUpdater {
             return null;
 
         String startedAt = LocalDateTime.ofInstant(Instant.now(), JST_ZONE).toString();
+        final String startedAtValue = ((TextCustomField) startedAt.get()).getValue();
+        if (startedAtValue != null && !startedAtValue.isBlank()) {
+            startedAt = startedAtValue + ";" + startedAt;
+        }
         return client.updateIssue(new UpdateIssueParams(issue.getId()).textCustomField(field.get().getId(), startedAt));
     }
 }

--- a/lambda/src/main/java/com/lambda/IssueUpdater.java
+++ b/lambda/src/main/java/com/lambda/IssueUpdater.java
@@ -76,7 +76,6 @@ public class IssueUpdater {
                 LocalDateTime endAt = LocalDateTime.parse(startAtArray[i + 1]);
                 elapsed = elapsed.plus(new WorkdayUtils().calculateWorkingHours(startAt, endAt));
             }
-            elapsed = new WorkdayUtils().calculateWorkingHours(LocalDateTime.parse(startedAtValue), endAt);
         } catch (DateTimeParseException ex) {
         }
         return elapsed;

--- a/lambda/src/main/java/com/lambda/IssueUpdater.java
+++ b/lambda/src/main/java/com/lambda/IssueUpdater.java
@@ -46,7 +46,7 @@ public class IssueUpdater {
             final String startedAtValue = ((TextCustomField) startedAt.get()).getValue();
 
             if (startedAtValue != null && !startedAtValue.isBlank()) {
-                elapsed = extracted(elapsed, startedAtValue);
+                elapsed = extracted(startedAtValue);
             }
         }
 
@@ -65,8 +65,9 @@ public class IssueUpdater {
         return client.updateIssue(new UpdateIssueParams(issue.getId()).actualHours(actualHours));
     }
 
-    private Duration extracted(Duration elapsed, final String startedAtValue) {
+    private Duration extracted(final String startedAtValue) {
         // get elapsed time from the started time in hours
+        Duration elapsed = Duration.ZERO;
         try {
             final String[] startAtArray = startedAtValue.split(";");
             startAtArray[startAtArray.length - 1] = LocalDateTime.ofInstant(Instant.now(), JST_ZONE).toString();


### PR DESCRIPTION
We append the new time instead of overriding it, allowing us to calculate the total time by summing the durations.
ex:
Start implementing task A at 2024/12/19 10:00, updated status to In Progress => Started at will be 2024/12/19 10:00
Some urgent task happen at 2024/12/19 11:30, pending the task A, update task A status to Open =>  Started at will be 2024/12/19 10:00; 2024/12/19 11:30
Finished handle urgent task at 2024/12/19 14:30, continue implement the task A, updated status to In Progress again => Started at will be 2024/12/19 10:00; 2024/12/19 11:30; 2024/12/19 14:30
Finished implementing task A at 2024/12/19 16:30, update status to Close => Actual hour will be = 1.5 h (2024/12/19 11:30 - 2024/12/19 10:00 ) + 2h ( 2024/12/19 16:30 -  2024/12/19 14:30 )