### PR TITLE
fix: change timestamp list initialization to use ArrayList for mutability 

### DIFF
--- a/lambda/src/main/java/com/lambda/IssueUpdater.java
+++ b/lambda/src/main/java/com/lambda/IssueUpdater.java
@@ -7,6 +7,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -71,7 +72,7 @@ public class IssueUpdater {
         Duration elapsed = Duration.ZERO;
         try {
             final String[] startAtArray = startedAtValue.split(";");
-            List<String> timesList = Arrays.asList(startAtArray);
+            List<String> timesList = new ArrayList<>(Arrays.asList(startAtArray));
             timesList.add(LocalDateTime.ofInstant(Instant.now(), JST_ZONE).toString());
 
             for (int i = 0; i < timesList.size() - 1; i += 2) {


### PR DESCRIPTION
We got exception
```
java.lang.UnsupportedOperationException: java.lang.UnsupportedOperationException
java.lang.UnsupportedOperationException
	at java.base/java.util.AbstractList.add(Unknown Source)
	at java.base/java.util.AbstractList.add(Unknown Source)
	at com.lambda.IssueUpdater.extracted(IssueUpdater.java:75)
	at com.lambda.IssueUpdater.setActualHours(IssueUpdater.java:50)
	at com.lambda.BacklogTimeRecorder.handleRequest(BacklogTimeRecorder.java:53)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source)

```