### PR TITLE
Implement milestone updates with start/due date fields

### DIFF
--- a/lambda/src/main/java/com/lambda/BacklogTimeRecorder.java
+++ b/lambda/src/main/java/com/lambda/BacklogTimeRecorder.java
@@ -32,6 +32,20 @@ public class BacklogTimeRecorder implements RequestHandler<APIGatewayV2HTTPEvent
             return returnText("Issue is null", 204);
         }
 
+        final String apiKey = System.getenv("BACKLOG_API_KEY");
+        if (apiKey == null) {
+            throw new RuntimeException("BACKLOG_API_KEY is not set");
+        }
+        final IssueUpdater updater = new IssueUpdater(apiKey);
+
+        // Check for start date or due date changes
+        boolean hasDateChange = issue.getChanges().stream()
+            .anyMatch(change -> change.getField().equals("startDate") || change.getField().equals("dueDate"));
+        
+        if (hasDateChange) {
+            updater.updateMilestones(issue.getId());
+        }
+
         int newStatus = issue.getChanges().stream()
             .filter(change -> change.getField().equals("status"))
             .findFirst()
@@ -40,12 +54,6 @@ public class BacklogTimeRecorder implements RequestHandler<APIGatewayV2HTTPEvent
         if (newStatus == 0) {
             return returnText("Status did not change", 204);
         }
-
-        final String apiKey = System.getenv("BACKLOG_API_KEY");
-        if (apiKey == null) {
-            throw new RuntimeException("BACKLOG_API_KEY is not set");
-        }
-        final IssueUpdater updater = new IssueUpdater(apiKey);
 
         com.nulabinc.backlog4j.Issue updatedIssue = null;
         switch (StatusType.valueOf(newStatus)) {

--- a/lambda/src/main/java/com/lambda/BacklogTimeRecorder.java
+++ b/lambda/src/main/java/com/lambda/BacklogTimeRecorder.java
@@ -43,7 +43,11 @@ public class BacklogTimeRecorder implements RequestHandler<APIGatewayV2HTTPEvent
             .anyMatch(change -> change.getField().equals("startDate") || change.getField().equals("dueDate"));
         
         if (hasDateChange) {
-            updater.updateMilestones(issue.getId());
+            try {
+                updater.updateMilestones(issue.getId());
+            } catch (Exception e) {
+                logger.log("Failed to update milestones for issue " + issue.getId() + ": " + e.getMessage(), LogLevel.ERROR);
+            }
         }
 
         int newStatus = issue.getChanges().stream()

--- a/lambda/src/main/java/com/lambda/IssueUpdater.java
+++ b/lambda/src/main/java/com/lambda/IssueUpdater.java
@@ -4,6 +4,7 @@ import com.lambda.utils.WorkdayUtils;
 import java.text.DecimalFormat;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.time.ZoneId;
@@ -118,9 +119,9 @@ public class IssueUpdater {
             return null;
         }
         
-        // Convert to LocalDateTime
-        final LocalDateTime start = LocalDateTime.ofInstant(startDate.toInstant(), JST_ZONE);
-        final LocalDateTime due = LocalDateTime.ofInstant(dueDate.toInstant(), JST_ZONE);
+        // Convert to LocalDate (dates only, no time component)
+        final LocalDate start = LocalDate.ofInstant(startDate.toInstant(), JST_ZONE);
+        final LocalDate due = LocalDate.ofInstant(dueDate.toInstant(), JST_ZONE);
         
         // Calculate required milestones in YYYY-MMM format
         final Set<String> requiredMilestones = calculateRequiredMilestones(start, due);
@@ -160,7 +161,7 @@ public class IssueUpdater {
             .milestoneIds(allMilestoneIds));
     }
     
-    private Set<String> calculateRequiredMilestones(final LocalDateTime start, final LocalDateTime due) {
+    private Set<String> calculateRequiredMilestones(final LocalDate start, final LocalDate due) {
         final Set<String> milestones = new HashSet<>();
         final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MMM");
         

--- a/lambda/src/main/java/com/lambda/IssueUpdater.java
+++ b/lambda/src/main/java/com/lambda/IssueUpdater.java
@@ -5,17 +5,24 @@ import java.text.DecimalFormat;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.nulabinc.backlog4j.BacklogClient;
 import com.nulabinc.backlog4j.BacklogClientFactory;
 import com.nulabinc.backlog4j.CustomField;
 import com.nulabinc.backlog4j.Issue;
+import com.nulabinc.backlog4j.Milestone;
 import com.nulabinc.backlog4j.api.option.UpdateIssueParams;
 import com.nulabinc.backlog4j.conf.BacklogConfigure;
 import com.nulabinc.backlog4j.conf.BacklogJpConfigure;
@@ -98,5 +105,73 @@ public class IssueUpdater {
             startedAt = startedAtValue + ";" + startedAt;
         }
         return client.updateIssue(new UpdateIssueParams(issue.getId()).textCustomField(field.get().getId(), startedAt));
+    }
+
+    public Issue updateMilestones(final int issueId) {
+        final Issue issue = client.getIssue(issueId);
+        
+        // Get start date and due date
+        final Date startDate = issue.getStartDate();
+        final Date dueDate = issue.getDueDate();
+        
+        if (startDate == null || dueDate == null) {
+            return null;
+        }
+        
+        // Convert to LocalDateTime
+        final LocalDateTime start = LocalDateTime.ofInstant(startDate.toInstant(), JST_ZONE);
+        final LocalDateTime due = LocalDateTime.ofInstant(dueDate.toInstant(), JST_ZONE);
+        
+        // Calculate required milestones in YYYY-MMM format
+        final Set<String> requiredMilestones = calculateRequiredMilestones(start, due);
+        
+        // Get current milestones
+        final Set<String> currentMilestoneNames = issue.getMilestone().stream()
+            .map(Milestone::getName)
+            .collect(Collectors.toSet());
+        
+        // Get all project milestones
+        final List<Milestone> projectMilestones = client.getMilestones(issue.getProjectId());
+        
+        // Find milestones to add (required but not already set)
+        final Set<String> milestonesToAdd = requiredMilestones.stream()
+            .filter(name -> !currentMilestoneNames.contains(name))
+            .collect(Collectors.toSet());
+        
+        if (milestonesToAdd.isEmpty()) {
+            return null;
+        }
+        
+        // Get milestone IDs for the ones to add
+        final List<Long> newMilestoneIds = projectMilestones.stream()
+            .filter(m -> milestonesToAdd.contains(m.getName()))
+            .map(Milestone::getId)
+            .collect(Collectors.toList());
+        
+        // Combine existing milestone IDs with new ones
+        final List<Long> allMilestoneIds = new ArrayList<>();
+        allMilestoneIds.addAll(issue.getMilestone().stream()
+            .map(Milestone::getId)
+            .collect(Collectors.toList()));
+        allMilestoneIds.addAll(newMilestoneIds);
+        
+        // Update issue with all milestones
+        return client.updateIssue(new UpdateIssueParams(issue.getId())
+            .milestoneIds(allMilestoneIds));
+    }
+    
+    private Set<String> calculateRequiredMilestones(final LocalDateTime start, final LocalDateTime due) {
+        final Set<String> milestones = new HashSet<>();
+        final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MMM");
+        
+        YearMonth current = YearMonth.from(start);
+        final YearMonth end = YearMonth.from(due);
+        
+        while (!current.isAfter(end)) {
+            milestones.add(current.format(formatter));
+            current = current.plusMonths(1);
+        }
+        
+        return milestones;
     }
 }

--- a/lambda/src/main/java/com/lambda/models/Issue.java
+++ b/lambda/src/main/java/com/lambda/models/Issue.java
@@ -3,6 +3,7 @@ package com.lambda.models;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -21,6 +22,8 @@ public class Issue {
     @JsonDeserialize(as = StatusJSONImpl.class)
     Status status;
     String summary;
+    Date startDate;
+    Date dueDate;
 
     public int getId() {
         return id;
@@ -43,5 +46,13 @@ public class Issue {
 
     public String getSummary() {
         return summary;
+    }
+
+    public Date getStartDate() {
+        return startDate;
+    }
+
+    public Date getDueDate() {
+        return dueDate;
     }
 }

--- a/lambda/src/main/java/com/lambda/models/Issue.java
+++ b/lambda/src/main/java/com/lambda/models/Issue.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.nulabinc.backlog4j.Change;
@@ -22,7 +23,9 @@ public class Issue {
     @JsonDeserialize(as = StatusJSONImpl.class)
     Status status;
     String summary;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     Date startDate;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     Date dueDate;
 
     public int getId() {

--- a/lambda/src/test/java/com/lambda/IssueUpdaterTest.java
+++ b/lambda/src/test/java/com/lambda/IssueUpdaterTest.java
@@ -3,7 +3,7 @@ package com.lambda;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.time.Month;
 import java.util.Set;
 
@@ -15,8 +15,8 @@ public class IssueUpdaterTest {
     @Test
     public void testCalculateRequiredMilestones_SameMonth() throws Exception {
         // Test when start and due date are in the same month
-        LocalDateTime start = LocalDateTime.of(2026, Month.JANUARY, 5, 10, 0);
-        LocalDateTime due = LocalDateTime.of(2026, Month.JANUARY, 25, 18, 0);
+        LocalDate start = LocalDate.of(2026, Month.JANUARY, 5);
+        LocalDate due = LocalDate.of(2026, Month.JANUARY, 25);
 
         Set<String> milestones = invokeCalculateRequiredMilestones(start, due);
 
@@ -27,8 +27,8 @@ public class IssueUpdaterTest {
     @Test
     public void testCalculateRequiredMilestones_TwoMonths() throws Exception {
         // Test when start and due date span two months
-        LocalDateTime start = LocalDateTime.of(2026, Month.JANUARY, 15, 10, 0);
-        LocalDateTime due = LocalDateTime.of(2026, Month.FEBRUARY, 10, 18, 0);
+        LocalDate start = LocalDate.of(2026, Month.JANUARY, 15);
+        LocalDate due = LocalDate.of(2026, Month.FEBRUARY, 10);
 
         Set<String> milestones = invokeCalculateRequiredMilestones(start, due);
 
@@ -40,8 +40,8 @@ public class IssueUpdaterTest {
     @Test
     public void testCalculateRequiredMilestones_MultipleMonths() throws Exception {
         // Test when start and due date span multiple months
-        LocalDateTime start = LocalDateTime.of(2026, Month.JANUARY, 15, 10, 0);
-        LocalDateTime due = LocalDateTime.of(2026, Month.APRIL, 30, 18, 0);
+        LocalDate start = LocalDate.of(2026, Month.JANUARY, 15);
+        LocalDate due = LocalDate.of(2026, Month.APRIL, 30);
 
         Set<String> milestones = invokeCalculateRequiredMilestones(start, due);
 
@@ -55,8 +55,8 @@ public class IssueUpdaterTest {
     @Test
     public void testCalculateRequiredMilestones_AcrossYears() throws Exception {
         // Test when start and due date span across year boundary
-        LocalDateTime start = LocalDateTime.of(2025, Month.DECEMBER, 15, 10, 0);
-        LocalDateTime due = LocalDateTime.of(2026, Month.FEBRUARY, 28, 18, 0);
+        LocalDate start = LocalDate.of(2025, Month.DECEMBER, 15);
+        LocalDate due = LocalDate.of(2026, Month.FEBRUARY, 28);
 
         Set<String> milestones = invokeCalculateRequiredMilestones(start, due);
 
@@ -69,8 +69,8 @@ public class IssueUpdaterTest {
     @Test
     public void testCalculateRequiredMilestones_FullYear() throws Exception {
         // Test when start and due date span a full year
-        LocalDateTime start = LocalDateTime.of(2026, Month.JANUARY, 1, 10, 0);
-        LocalDateTime due = LocalDateTime.of(2026, Month.DECEMBER, 31, 18, 0);
+        LocalDate start = LocalDate.of(2026, Month.JANUARY, 1);
+        LocalDate due = LocalDate.of(2026, Month.DECEMBER, 31);
 
         Set<String> milestones = invokeCalculateRequiredMilestones(start, due);
 
@@ -92,8 +92,8 @@ public class IssueUpdaterTest {
     @Test
     public void testCalculateRequiredMilestones_FirstAndLastDayOfMonth() throws Exception {
         // Test edge case: first day to last day of different months
-        LocalDateTime start = LocalDateTime.of(2026, Month.MARCH, 1, 0, 0);
-        LocalDateTime due = LocalDateTime.of(2026, Month.MAY, 31, 23, 59);
+        LocalDate start = LocalDate.of(2026, Month.MARCH, 1);
+        LocalDate due = LocalDate.of(2026, Month.MAY, 31);
 
         Set<String> milestones = invokeCalculateRequiredMilestones(start, due);
 
@@ -106,8 +106,8 @@ public class IssueUpdaterTest {
     @Test
     public void testCalculateRequiredMilestones_LeapYear() throws Exception {
         // Test leap year scenario
-        LocalDateTime start = LocalDateTime.of(2024, Month.FEBRUARY, 1, 10, 0);
-        LocalDateTime due = LocalDateTime.of(2024, Month.FEBRUARY, 29, 18, 0);
+        LocalDate start = LocalDate.of(2024, Month.FEBRUARY, 1);
+        LocalDate due = LocalDate.of(2024, Month.FEBRUARY, 29);
 
         Set<String> milestones = invokeCalculateRequiredMilestones(start, due);
 
@@ -119,13 +119,13 @@ public class IssueUpdaterTest {
      * Helper method to invoke private calculateRequiredMilestones method using reflection
      */
     @SuppressWarnings("unchecked")
-    private Set<String> invokeCalculateRequiredMilestones(LocalDateTime start, LocalDateTime due) throws Exception {
+    private Set<String> invokeCalculateRequiredMilestones(LocalDate start, LocalDate due) throws Exception {
         // Create a mock IssueUpdater instance with dummy API key
         IssueUpdater updater = new IssueUpdater("dummy-api-key-for-testing");
 
         // Get the private method using reflection
         Method method = IssueUpdater.class.getDeclaredMethod("calculateRequiredMilestones", 
-            LocalDateTime.class, LocalDateTime.class);
+            LocalDate.class, LocalDate.class);
         method.setAccessible(true);
 
         // Invoke the method

--- a/lambda/src/test/java/com/lambda/IssueUpdaterTest.java
+++ b/lambda/src/test/java/com/lambda/IssueUpdaterTest.java
@@ -1,0 +1,134 @@
+package com.lambda;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class IssueUpdaterTest {
+
+    @Test
+    public void testCalculateRequiredMilestones_SameMonth() throws Exception {
+        // Test when start and due date are in the same month
+        LocalDateTime start = LocalDateTime.of(2026, Month.JANUARY, 5, 10, 0);
+        LocalDateTime due = LocalDateTime.of(2026, Month.JANUARY, 25, 18, 0);
+
+        Set<String> milestones = invokeCalculateRequiredMilestones(start, due);
+
+        assertEquals(1, milestones.size());
+        assertTrue(milestones.contains("2026-Jan"));
+    }
+
+    @Test
+    public void testCalculateRequiredMilestones_TwoMonths() throws Exception {
+        // Test when start and due date span two months
+        LocalDateTime start = LocalDateTime.of(2026, Month.JANUARY, 15, 10, 0);
+        LocalDateTime due = LocalDateTime.of(2026, Month.FEBRUARY, 10, 18, 0);
+
+        Set<String> milestones = invokeCalculateRequiredMilestones(start, due);
+
+        assertEquals(2, milestones.size());
+        assertTrue(milestones.contains("2026-Jan"));
+        assertTrue(milestones.contains("2026-Feb"));
+    }
+
+    @Test
+    public void testCalculateRequiredMilestones_MultipleMonths() throws Exception {
+        // Test when start and due date span multiple months
+        LocalDateTime start = LocalDateTime.of(2026, Month.JANUARY, 15, 10, 0);
+        LocalDateTime due = LocalDateTime.of(2026, Month.APRIL, 30, 18, 0);
+
+        Set<String> milestones = invokeCalculateRequiredMilestones(start, due);
+
+        assertEquals(4, milestones.size());
+        assertTrue(milestones.contains("2026-Jan"));
+        assertTrue(milestones.contains("2026-Feb"));
+        assertTrue(milestones.contains("2026-Mar"));
+        assertTrue(milestones.contains("2026-Apr"));
+    }
+
+    @Test
+    public void testCalculateRequiredMilestones_AcrossYears() throws Exception {
+        // Test when start and due date span across year boundary
+        LocalDateTime start = LocalDateTime.of(2025, Month.DECEMBER, 15, 10, 0);
+        LocalDateTime due = LocalDateTime.of(2026, Month.FEBRUARY, 28, 18, 0);
+
+        Set<String> milestones = invokeCalculateRequiredMilestones(start, due);
+
+        assertEquals(3, milestones.size());
+        assertTrue(milestones.contains("2025-Dec"));
+        assertTrue(milestones.contains("2026-Jan"));
+        assertTrue(milestones.contains("2026-Feb"));
+    }
+
+    @Test
+    public void testCalculateRequiredMilestones_FullYear() throws Exception {
+        // Test when start and due date span a full year
+        LocalDateTime start = LocalDateTime.of(2026, Month.JANUARY, 1, 10, 0);
+        LocalDateTime due = LocalDateTime.of(2026, Month.DECEMBER, 31, 18, 0);
+
+        Set<String> milestones = invokeCalculateRequiredMilestones(start, due);
+
+        assertEquals(12, milestones.size());
+        assertTrue(milestones.contains("2026-Jan"));
+        assertTrue(milestones.contains("2026-Feb"));
+        assertTrue(milestones.contains("2026-Mar"));
+        assertTrue(milestones.contains("2026-Apr"));
+        assertTrue(milestones.contains("2026-May"));
+        assertTrue(milestones.contains("2026-Jun"));
+        assertTrue(milestones.contains("2026-Jul"));
+        assertTrue(milestones.contains("2026-Aug"));
+        assertTrue(milestones.contains("2026-Sep"));
+        assertTrue(milestones.contains("2026-Oct"));
+        assertTrue(milestones.contains("2026-Nov"));
+        assertTrue(milestones.contains("2026-Dec"));
+    }
+
+    @Test
+    public void testCalculateRequiredMilestones_FirstAndLastDayOfMonth() throws Exception {
+        // Test edge case: first day to last day of different months
+        LocalDateTime start = LocalDateTime.of(2026, Month.MARCH, 1, 0, 0);
+        LocalDateTime due = LocalDateTime.of(2026, Month.MAY, 31, 23, 59);
+
+        Set<String> milestones = invokeCalculateRequiredMilestones(start, due);
+
+        assertEquals(3, milestones.size());
+        assertTrue(milestones.contains("2026-Mar"));
+        assertTrue(milestones.contains("2026-Apr"));
+        assertTrue(milestones.contains("2026-May"));
+    }
+
+    @Test
+    public void testCalculateRequiredMilestones_LeapYear() throws Exception {
+        // Test leap year scenario
+        LocalDateTime start = LocalDateTime.of(2024, Month.FEBRUARY, 1, 10, 0);
+        LocalDateTime due = LocalDateTime.of(2024, Month.FEBRUARY, 29, 18, 0);
+
+        Set<String> milestones = invokeCalculateRequiredMilestones(start, due);
+
+        assertEquals(1, milestones.size());
+        assertTrue(milestones.contains("2024-Feb"));
+    }
+
+    /**
+     * Helper method to invoke private calculateRequiredMilestones method using reflection
+     */
+    @SuppressWarnings("unchecked")
+    private Set<String> invokeCalculateRequiredMilestones(LocalDateTime start, LocalDateTime due) throws Exception {
+        // Create a mock IssueUpdater instance with dummy API key
+        IssueUpdater updater = new IssueUpdater("dummy-api-key-for-testing");
+
+        // Get the private method using reflection
+        Method method = IssueUpdater.class.getDeclaredMethod("calculateRequiredMilestones", 
+            LocalDateTime.class, LocalDateTime.class);
+        method.setAccessible(true);
+
+        // Invoke the method
+        return (Set<String>) method.invoke(updater, start, due);
+    }
+}

--- a/lambda/src/test/java/com/lambda/models/IssueDeserializationTest.java
+++ b/lambda/src/test/java/com/lambda/models/IssueDeserializationTest.java
@@ -1,0 +1,108 @@
+package com.lambda.models;
+
+import com.nulabinc.backlog4j.internal.json.Jackson;
+import org.junit.jupiter.api.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class IssueDeserializationTest {
+
+    @Test
+    public void testDeserializeIssueWithDates() {
+        String json = """
+            {
+                "id": 123,
+                "summary": "Test Issue",
+                "startDate": "2023-11-16",
+                "dueDate": "2023-11-20"
+            }
+            """;
+
+        Issue issue = Jackson.fromJsonString(json, Issue.class);
+
+        assertNotNull(issue);
+        assertEquals(123, issue.getId());
+        assertEquals("Test Issue", issue.getSummary());
+        
+        // Verify dates are parsed correctly
+        assertNotNull(issue.getStartDate());
+        assertNotNull(issue.getDueDate());
+        
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        assertEquals("2023-11-16", sdf.format(issue.getStartDate()));
+        assertEquals("2023-11-20", sdf.format(issue.getDueDate()));
+    }
+
+    @Test
+    public void testDeserializeIssueWithNullDates() {
+        String json = """
+            {
+                "id": 456,
+                "summary": "Test Issue Without Dates",
+                "startDate": null,
+                "dueDate": null
+            }
+            """;
+
+        Issue issue = Jackson.fromJsonString(json, Issue.class);
+
+        assertNotNull(issue);
+        assertEquals(456, issue.getId());
+        assertEquals("Test Issue Without Dates", issue.getSummary());
+        
+        // Verify dates are null
+        assertNull(issue.getStartDate());
+        assertNull(issue.getDueDate());
+    }
+
+    @Test
+    public void testDeserializeIssueWithoutDateFields() {
+        String json = """
+            {
+                "id": 789,
+                "summary": "Test Issue Missing Date Fields"
+            }
+            """;
+
+        Issue issue = Jackson.fromJsonString(json, Issue.class);
+
+        assertNotNull(issue);
+        assertEquals(789, issue.getId());
+        assertEquals("Test Issue Missing Date Fields", issue.getSummary());
+        
+        // Verify dates are null when not present in JSON
+        assertNull(issue.getStartDate());
+        assertNull(issue.getDueDate());
+    }
+
+    @Test
+    public void testDeserializeRealWebhookPayload() {
+        // Real payload from issue.json
+        String json = """
+            {
+                "id": 39751072,
+                "key_id": 809,
+                "summary": "Test summary",
+                "startDate": "2023-11-16",
+                "dueDate": "2023-11-20",
+                "estimatedHours": null,
+                "actualHours": null
+            }
+            """;
+
+        Issue issue = Jackson.fromJsonString(json, Issue.class);
+
+        assertNotNull(issue);
+        assertEquals(39751072, issue.getId());
+        
+        assertNotNull(issue.getStartDate());
+        assertNotNull(issue.getDueDate());
+        
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        assertEquals("2023-11-16", sdf.format(issue.getStartDate()));
+        assertEquals("2023-11-20", sdf.format(issue.getDueDate()));
+    }
+}


### PR DESCRIPTION
Implement a feature where if an Issue has `Start Date` and `Due Date` set, it will automatically update Milestones according to these rules:
- Add Milestone in format YYYY-MMM (2026-Jan) if the time period falls within that milestone's range, don't add if that milestone is already set
- Don't remove already set milestones

Enhance the Issue model by adding start and due date fields, enabling milestone updates based on changes to these dates. Include unit tests to verify milestone calculations across various date scenarios.