### PR TITLE
Fix milestone update logic to check limitDate instead of dueDate

### DIFF
--- a/lambda/src/main/java/com/lambda/BacklogTimeRecorder.java
+++ b/lambda/src/main/java/com/lambda/BacklogTimeRecorder.java
@@ -40,7 +40,7 @@ public class BacklogTimeRecorder implements RequestHandler<APIGatewayV2HTTPEvent
 
         // Check for start date or due date changes
         boolean hasDateChange = issue.getChanges().stream()
-            .anyMatch(change -> change.getField().equals("startDate") || change.getField().equals("dueDate"));
+            .anyMatch(change -> change.getField().equals("startDate") || change.getField().equals("limitDate"));
         
         if (hasDateChange) {
             updater.updateMilestones(issue.getId());


### PR DESCRIPTION
Update the milestone update logic to check for changes in the limitDate field instead of the dueDate field
```json
{
 ...
"changes": [
            {
                "field": "startDate",
                "new_value": "2026-01-01",
                "old_value": "2025-12-10",
                "type": "standard"
            },
            {
                "field": "limitDate",
                "new_value": "2026-03-25",
                "old_value": "2026-03-26",
                "type": "standard"
            }
        ]
...
}
```