### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/FaberTechnology/backlog-time-recorder/security/code-scanning/1](https://github.com/FaberTechnology/backlog-time-recorder/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/deploy.yml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
For this workflow, the safest minimal non-breaking baseline is:

- `contents: read`

This matches CodeQL’s recommended minimal starting point and does not expand privileges. It preserves existing functionality unless a step actually requires additional GitHub API write scopes (none are evident in the provided snippet). Place this block immediately after the `on:` trigger section (or after `name:`/`on:` block), before `jobs:`.

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
