### PR TITLE
Prevent overwriting actual hours in ActualHoursUpdateStrategy

### DIFF
--- a/lambda/src/main/java/com/lambda/strategies/ActualHoursUpdateStrategy.java
+++ b/lambda/src/main/java/com/lambda/strategies/ActualHoursUpdateStrategy.java
@@ -22,7 +22,10 @@ public class ActualHoursUpdateStrategy implements UpdateStrategy {
 
     @Override
     public boolean canApply(final IssueWrapper issueWrapper, final ProjectContext projectContext) {
-        return issueWrapper.getNewStatusCode() == StatusType.Closed.getIntValue();
+        if (issueWrapper.getNewStatusCode() != StatusType.Closed.getIntValue()) {
+            return false;
+        }
+        return !issueWrapper.getActualHours().isPresent();
     }
 
     @Override

--- a/lambda/src/test/java/com/lambda/strategies/ActualHoursUpdateStrategyTest.java
+++ b/lambda/src/test/java/com/lambda/strategies/ActualHoursUpdateStrategyTest.java
@@ -1,0 +1,72 @@
+package com.lambda.strategies;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import com.lambda.helpers.TimeTrackingHelper;
+import com.lambda.helpers.WorkScheduleHelper;
+import com.lambda.models.IssueWrapper;
+import com.nulabinc.backlog4j.Issue.StatusType;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ActualHoursUpdateStrategyTest {
+
+    private final ActualHoursUpdateStrategy strategy =
+            new ActualHoursUpdateStrategy(new TimeTrackingHelper(new WorkScheduleHelper()));
+
+    @Test
+    public void canApply_closedStatus_andActualHoursNotSet_returnsTrue() {
+        final IssueWrapper wrapper = new StubIssueWrapper(
+                StatusType.Closed.getIntValue(), Optional.empty());
+
+        assertTrue(strategy.canApply(wrapper, null));
+    }
+
+    @Test
+    public void canApply_closedStatus_butActualHoursAlreadySet_returnsFalse() {
+        final IssueWrapper wrapper = new StubIssueWrapper(
+                StatusType.Closed.getIntValue(), Optional.of(3.5f));
+
+        assertFalse(strategy.canApply(wrapper, null));
+    }
+
+    @Test
+    public void canApply_closedStatus_actualHoursIsZero_returnsFalse() {
+        final IssueWrapper wrapper = new StubIssueWrapper(
+                StatusType.Closed.getIntValue(), Optional.of(0f));
+
+        assertFalse(strategy.canApply(wrapper, null));
+    }
+
+    @Test
+    public void canApply_nonClosedStatus_returnsFalse() {
+        final IssueWrapper wrapper = new StubIssueWrapper(
+                StatusType.InProgress.getIntValue(), Optional.empty());
+
+        assertFalse(strategy.canApply(wrapper, null));
+    }
+
+    private static class StubIssueWrapper extends IssueWrapper {
+        private final int statusCode;
+        private final Optional<Float> actualHours;
+
+        StubIssueWrapper(final int statusCode, final Optional<Float> actualHours) {
+            super(null, statusCode, false);
+            this.statusCode = statusCode;
+            this.actualHours = actualHours;
+        }
+
+        @Override
+        public int getNewStatusCode() {
+            return statusCode;
+        }
+
+        @Override
+        public Optional<Float> getActualHours() {
+            return actualHours;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Updated the `ActualHoursUpdateStrategy` to prevent overwriting actual hours that have already been set on closed issues. Previously, the strategy would apply to any closed issue regardless of whether actual hours were already populated.

## Changes
- **Modified `ActualHoursUpdateStrategy.canApply()`**: Enhanced the logic to check not only that an issue is closed, but also that actual hours have not already been set. The strategy now returns `false` if actual hours are present (including zero values).
- **Added comprehensive test coverage** (`ActualHoursUpdateStrategyTest`): Created unit tests covering all scenarios:
  - Closed status with no actual hours set (should apply)
  - Closed status with actual hours already set (should not apply)
  - Closed status with actual hours set to zero (should not apply)
  - Non-closed status (should not apply)

## Implementation Details
The test suite uses a `StubIssueWrapper` to isolate the strategy logic and verify the correct behavior without requiring full issue objects. This ensures the strategy respects existing actual hours data and only calculates them when necessary.

https://claude.ai/code/session_0178ZcCSbFv5XuXTcJLXr8Vv